### PR TITLE
refactor(normalization): extract let-binding inlining helper

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
@@ -531,6 +531,44 @@ object TypedExprNormalization {
     }
   }
 
+  private def inlineLetBinding[A: Eq, V](
+      namerec: Option[Bindable],
+      arg: Bindable,
+      ex2: TypedExpr[A],
+      in1: TypedExpr[A],
+      rec1: RecursionKind,
+      tag: A,
+      original: TypedExpr[A],
+      scope: Scope[A],
+      typeEnv: TypeEnv[V]
+  )(implicit ev: V <:< Kind.Arg): Option[TypedExpr[A]] = {
+    val cnt = in1.freeVarsDup.count(_ == arg)
+    if (cnt > 0) {
+      // the arg is needed
+      val isSimp = Impl.isSimple(ex2, lambdaSimple = true)
+      val shouldInline = (!rec1.isRecursive) && {
+        (cnt == 1) || isSimp
+      }
+      // we don't want to inline a value that is itself a function call
+      // inside of lambdas
+      val inlined =
+        if (shouldInline)
+          substitute(arg, ex2, in1, enterLambda = isSimp)
+        else None
+      inlined match {
+        case Some(il) =>
+          normalize1(namerec, il, scope, typeEnv)
+        case None =>
+          val step = Let(arg, ex2, in1, rec1, tag)
+          if ((step: TypedExpr[A]) === original) None
+          else normalize1(namerec, step, scope, typeEnv)
+      }
+    } else {
+      // let x = y in z if x isn't free in z = z
+      Some(in1)
+    }
+  }
+
   // if you have made one step of progress, use this to recurse
   // so we don't throw away if we don't progress more
   private def normalize1[A: Eq, V](
@@ -1345,31 +1383,17 @@ object TypedExprNormalization {
                       }
                       normalize1(namerec, Match(marg, b1, mtag), scope, typeEnv)
                     case _ =>
-                      val cnt = in1.freeVarsDup.count(_ == arg)
-                      if (cnt > 0) {
-                        // the arg is needed
-                        val isSimp = Impl.isSimple(ex2, lambdaSimple = true)
-                        val shouldInline = (!rec1.isRecursive) && {
-                          (cnt == 1) || isSimp
-                        }
-                        // we don't want to inline a value that is itself a function call
-                        // inside of lambdas
-                        val inlined =
-                          if (shouldInline)
-                            substitute(arg, ex2, in1, enterLambda = isSimp)
-                          else None
-                        inlined match {
-                          case Some(il) =>
-                            normalize1(namerec, il, scope, typeEnv)
-                          case None =>
-                            val step = Let(arg, ex2, in1, rec1, tag)
-                            if ((step: TypedExpr[A]) === te) None
-                            else normalize1(namerec, step, scope, typeEnv)
-                        }
-                      } else {
-                        // let x = y in z if x isn't free in z = z
-                        Some(in1)
-                      }
+                      inlineLetBinding(
+                        namerec = namerec,
+                        arg = arg,
+                        ex2 = ex2,
+                        in1 = in1,
+                        rec1 = rec1,
+                        tag = tag,
+                        original = te,
+                        scope = scope,
+                        typeEnv = typeEnv
+                      )
                   }
               }
           }


### PR DESCRIPTION
## Summary
- extract let substitution/inlining logic into helper-level units
- reduce branch complexity inside normalization dispatch
- targets `snoble/bosatsu` stacked branch sequence

## Test plan
- [x] `nix-shell --run \"cd ../bosatsu && sbt 'coreJVM/testOnly dev.bosatsu.TypedExprNormalizationCharTest dev.bosatsu.TypedExprTest'\"`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor that moves existing let-inlining/substitution logic into a shared helper; behavior should be unchanged aside from potential edge-case regressions in normalization if the extracted parameters don’t exactly match prior checks.
> 
> **Overview**
> Extracts the let-binding inlining/substitution logic from the `Let` normalization path into a new helper (`inlineLetBinding`) and replaces the inlined branch with a single call.
> 
> This reduces branching/duplication while preserving the prior decisions around dropping unused lets, selectively inlining non-recursive bindings, and re-normalizing after substitution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0f9e8a76948bdcecd7d554b300448b2ec825fa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->