### PR TITLE
feat(normalization): expose normalization artifact API

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
@@ -307,6 +307,11 @@ object TypedExprNormalization {
     }
   }
 
+  final case class LetNormalizationArtifacts[A](
+      preInlining: List[(Bindable, RecursionKind, TypedExpr[A])],
+      normalized: List[(Bindable, RecursionKind, TypedExpr[A])]
+  )
+
   private def normalizeAllWithMode[A: Eq, V](
       pack: PackageName,
       lets: List[(Bindable, RecursionKind, TypedExpr[A])],
@@ -352,6 +357,19 @@ object TypedExprNormalization {
   ): List[(Bindable, RecursionKind, TypedExpr[A])] =
     normalizeAllWithMode(pack, lets, typeEnv, NormalizationMode.Full)
 
+  def normalizeAllWithArtifacts[A: Eq, V](
+      pack: PackageName,
+      lets: List[(Bindable, RecursionKind, TypedExpr[A])],
+      typeEnv: TypeEnv[V]
+  )(implicit
+      ev: V <:< Kind.Arg
+  ): LetNormalizationArtifacts[A] = {
+    val preInlining =
+      normalizeAllWithMode(pack, lets, typeEnv, NormalizationMode.StructuralOnly)
+    val normalized = normalizeAllWithMode(pack, lets, typeEnv, NormalizationMode.Full)
+    LetNormalizationArtifacts(preInlining = preInlining, normalized = normalized)
+  }
+
   def normalizeProgram[A, V](
       p: PackageName,
       fullTypeEnv: TypeEnv[V],
@@ -375,6 +393,23 @@ object TypedExprNormalization {
     val normalLets =
       normalizeAllWithMode(p, lets, fullTypeEnv, NormalizationMode.StructuralOnly)
     Program(typeEnv, normalLets, extDefs, stmts)
+  }
+
+  def normalizeProgramWithArtifacts[A, V](
+      p: PackageName,
+      fullTypeEnv: TypeEnv[V],
+      prog: Program[TypeEnv[V], TypedExpr[Declaration], A]
+  )(implicit
+      ev: V <:< Kind.Arg
+  ): (
+      Program[TypeEnv[V], TypedExpr[Declaration], A],
+      Program[TypeEnv[V], TypedExpr[Declaration], A]
+  ) = {
+    val Program(typeEnv, lets, extDefs, stmts) = prog
+    val artifacts = normalizeAllWithArtifacts(p, lets, fullTypeEnv)
+    val preInlining = Program(typeEnv, artifacts.preInlining, extDefs, stmts)
+    val normalized = Program(typeEnv, artifacts.normalized, extDefs, stmts)
+    (preInlining, normalized)
   }
 
   private def simplifyMatch[A: Eq, V](

--- a/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
@@ -3288,7 +3288,7 @@ x = Foo
     (unoptimizedExpr, normalizedExpr)
   }
 
-  test("normalizeStructuralOnly preserves call sites while full normalize inlines") {
+  test("normalizeAllWithArtifacts exposes pre-inlining call sites") {
     val stmts = Parser.unsafeParse(
       Statement.parser,
       """
@@ -3310,20 +3310,19 @@ g = y -> choose(id(y), y)
 
     val g = Identifier.Name("g")
 
-    val fullNormalizedExpr =
-      TypedExprNormalization
-        .normalizeAll(TestUtils.testPackage, unoptProgram.lets, fullTypeEnv)
-        .find(_._1 == g) match {
+    val artifacts = TypedExprNormalization.normalizeAllWithArtifacts(
+      TestUtils.testPackage,
+      unoptProgram.lets,
+      fullTypeEnv
+    )
+
+    val fullNormalizedExpr = artifacts.normalized.find(_._1 == g) match {
         case Some((_, _, te)) => te
         case None =>
           fail("missing let g in fully normalized lets")
       }
 
-    val structuralNormalizedExpr =
-      TypedExprNormalization
-        .normalizeStructuralOnly(TestUtils.testPackage, fullTypeEnv, unoptProgram)
-        .lets
-        .find(_._1 == g) match {
+    val structuralNormalizedExpr = artifacts.preInlining.find(_._1 == g) match {
         case Some((_, _, te)) => te
         case None =>
           fail("missing let g in structural-only normalized lets")
@@ -3338,6 +3337,18 @@ g = y -> choose(id(y), y)
 
     assertEquals(fullAppCount, 0)
     assert(structuralAppCount > 0)
+
+    val (preInliningProgram, normalizedProgram) =
+      TypedExprNormalization.normalizeProgramWithArtifacts(
+        TestUtils.testPackage,
+        fullTypeEnv,
+        unoptProgram
+      )
+
+    val fromProgramPreInlining = preInliningProgram.lets.find(_._1 == g).map(_._3)
+    val fromProgramNormalized = normalizedProgram.lets.find(_._1 == g).map(_._3)
+    assertEquals(fromProgramPreInlining, Some(structuralNormalizedExpr))
+    assertEquals(fromProgramNormalized, Some(fullNormalizedExpr))
   }
 
   test("if matches normalizes to same code as equivalent match") {


### PR DESCRIPTION
## Summary
- expose normalization artifact envelope for structural and fully normalized outputs
- update API consumers and tests to exercise artifact-returning paths
- targets `snoble/bosatsu` stacked branch sequence

## Test plan
- [x] `nix-shell --run \"cd ../bosatsu && sbt 'coreJVM/testOnly dev.bosatsu.TypedExprNormalizationCharTest dev.bosatsu.TypedExprTest'\"`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new public API wrappers and adjusts tests without changing the existing full-normalization behavior or core algorithms.
> 
> **Overview**
> Exposes a new normalization *artifact* API in `TypedExprNormalization` that returns both **structural-only (pre-inlining)** and **fully normalized** outputs (`LetNormalizationArtifacts`, `normalizeAllWithArtifacts`, and `normalizeProgramWithArtifacts`).
> 
> Updates `TypedExprTest` to consume these artifact-returning entrypoints and assert that pre-inlining results preserve call-site `App` nodes while full normalization removes them, and that program-level artifacts match the let-level outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54fe66886925872b57f132dc7a499db141163f1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->