### PR TITLE
feat(normalization): add sidecar ancestry coverage report

### DIFF
--- a/core/src/main/scala/dev/bosatsu/NormalizationProvenance.scala
+++ b/core/src/main/scala/dev/bosatsu/NormalizationProvenance.scala
@@ -51,6 +51,50 @@ object NormalizationProvenance {
 
       nodes.keysIterator.forall(visit)
     }
+
+    def ancestorsInclusive(roots: Iterable[ProvenanceId]): Set[ProvenanceId] = {
+      val seen = mutable.HashSet.empty[ProvenanceId]
+
+      def visit(id: ProvenanceId): Unit =
+        if (seen.add(id)) {
+          nodes.get(id).foreach { node =>
+            node.parents.foreach(visit)
+          }
+        }
+
+      roots.iterator.foreach(visit)
+      seen.toSet
+    }
+  }
+
+  final case class CoverageReport(
+      coveredNodeCount: Int,
+      uncoveredNodeCount: Int,
+      coveredRegions: Set[Region],
+      uncoveredRegions: Set[Region]
+  ) {
+    def summaryLine: String =
+      s"provenance coverage: $coveredNodeCount covered nodes, $uncoveredNodeCount uncovered nodes"
+  }
+
+  def coverageFromRoots[A](
+      dag: Dag[A],
+      roots: Iterable[ProvenanceId],
+      regionOf: A => Option[Region]
+  ): CoverageReport = {
+    val covered = dag.ancestorsInclusive(roots)
+    val all = dag.nodes.keySet
+    val uncovered = all -- covered
+
+    def regions(ids: Set[ProvenanceId]): Set[Region] =
+      ids.iterator.flatMap(id => dag.nodes.get(id).flatMap(n => regionOf(n.tag))).toSet
+
+    CoverageReport(
+      coveredNodeCount = covered.size,
+      uncoveredNodeCount = uncovered.size,
+      coveredRegions = regions(covered),
+      uncoveredRegions = regions(uncovered)
+    )
   }
 
   final class Builder[A] private () {

--- a/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
@@ -322,7 +322,14 @@ object TypedExprNormalization {
       provenance: NormalizationProvenance.Dag[Declaration],
       preInliningRoots: Map[Bindable, ProvenanceId],
       normalizedRoots: Map[Bindable, ProvenanceId]
-  )
+  ) {
+    def coverageReport: NormalizationProvenance.CoverageReport =
+      NormalizationProvenance.coverageFromRoots(
+        provenance,
+        normalizedRoots.values,
+        decl => Some(decl.region)
+      )
+  }
 
   private def normalizeAllWithMode[A: Eq, V](
       pack: PackageName,
@@ -507,6 +514,16 @@ object TypedExprNormalization {
       normalizedRoots = artifacts.normalizedRoots
     )
   }
+
+  def provenanceCoverageReport[A](
+      artifacts: LetNormalizationArtifacts[A],
+      regionOf: A => Option[Region]
+  ): NormalizationProvenance.CoverageReport =
+    NormalizationProvenance.coverageFromRoots(
+      artifacts.provenance,
+      artifacts.normalizedRoots.values,
+      regionOf
+    )
 
   private def simplifyMatch[A: Eq, V](
       namerec: Option[Bindable],

--- a/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
@@ -3351,6 +3351,13 @@ g = y -> choose(id(y), y)
       case _ => true
     })
 
+    val letCoverage = TypedExprNormalization.provenanceCoverageReport(
+      artifacts,
+      _ => None
+    )
+    assert(letCoverage.coveredNodeCount > 0)
+    assert(letCoverage.coveredNodeCount + letCoverage.uncoveredNodeCount > 0)
+
     val programArtifacts =
       TypedExprNormalization.normalizeProgramWithArtifacts(
         TestUtils.testPackage,
@@ -3366,6 +3373,11 @@ g = y -> choose(id(y), y)
     assertEquals(fromProgramNormalized, Some(fullNormalizedExpr))
     assertEquals(programArtifacts.preInliningRoots, artifacts.preInliningRoots)
     assertEquals(programArtifacts.normalizedRoots, artifacts.normalizedRoots)
+
+    val programCoverage = programArtifacts.coverageReport
+    assert(programCoverage.coveredNodeCount > 0)
+    assert(programCoverage.coveredRegions.nonEmpty)
+    assert(programCoverage.summaryLine.contains("provenance coverage"))
   }
 
   test("if matches normalizes to same code as equivalent match") {


### PR DESCRIPTION
## Summary
- compute provenance coverage from normalized-root ancestry closure
- expose coverage report API (counts, regions, summary output) on artifact paths
- targets `snoble/bosatsu` stacked branch sequence

## Test plan
- [x] `nix-shell --run \"cd ../bosatsu && sbt 'coreJVM/testOnly dev.bosatsu.TypedExprNormalizationCharTest dev.bosatsu.TypedExprTest'\"`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds read-only reporting utilities over existing provenance DAGs; no changes to normalization behavior or data mutation paths.
> 
> **Overview**
> Adds a provenance *coverage* utility that computes the ancestor-closure of given root nodes and reports covered vs uncovered provenance nodes, plus optional source `Region` sets and a `summaryLine` (`NormalizationProvenance.ancestorsInclusive`, `CoverageReport`, `coverageFromRoots`).
> 
> Exposes this report on normalization artifact APIs via `ProgramNormalizationArtifacts.coverageReport` and a helper `TypedExprNormalization.provenanceCoverageReport`, and extends `TypedExprTest` to assert basic coverage/region reporting for both let- and program-level artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e5bfeae52354ca9b2977e6e766b590ee1b0272b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->